### PR TITLE
Fix sidebar routing

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -32,7 +32,7 @@ const AppSidebar = () => {
               </SidebarMenuItem>
               <SidebarMenuItem>
                 <SidebarMenuButton>
-                  <Link href="input-typewriter">Input Typewriter</Link>
+                  <Link href="/input-typewriter">Input Typewriter</Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             </SidebarMenu>


### PR DESCRIPTION
Looks like you forgot the / before "input-typewriter" in one of your sidebar links. 